### PR TITLE
Update reveal.js to the latest version

### DIFF
--- a/wowchemy/assets/js/wowchemy-slides.js
+++ b/wowchemy/assets/js/wowchemy-slides.js
@@ -7,7 +7,7 @@ import * as params from '@params';
 import {fixMermaid} from './wowchemy-utils';
 
 // Enable core slide features.
-var enabledPlugins = [RevealMarkdown, RevealHighlight, RevealSearch, RevealNotes, RevealMath, RevealZoom];
+var enabledPlugins = [RevealMarkdown, RevealHighlight, RevealSearch, RevealNotes, RevealMath.MathJax3, RevealZoom];
 
 const isObject = function (o) {
   return o === Object(o) && !isArray(o) && typeof o !== 'function';

--- a/wowchemy/layouts/slides/baseof.html
+++ b/wowchemy/layouts/slides/baseof.html
@@ -5,7 +5,7 @@
   {{ .Scratch.Set "media_dir" $media_dir }}
 
   {{ $css := site.Data.assets.css }}
-  {{ $cdn_url_reveal := "https://cdn.jsdelivr.net/npm/reveal.js@4.1.0" }}
+  {{ $cdn_url_reveal := "https://cdn.jsdelivr.net/npm/reveal.js@4.2.1" }}
   {{ $js := site.Data.assets.js }}
 
   <meta charset="utf-8">


### PR DESCRIPTION
### Purpose

Following [this comment from Geo](https://github.com/wowchemy/wowchemy-hugo-themes/pull/2513#issuecomment-979463308), this PR updates reveal.js to the [latest version](https://github.com/hakimel/reveal.js/releases/tag/4.2.1), so now we can use [MathJax 3 as a math plugin](https://revealjs.com/math/#mathjax-3-4.2.0).